### PR TITLE
Pop Scope Changed in chat_screen.deart

### DIFF
--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -51,14 +51,18 @@ class _ChatScreenState extends State<ChatScreen> {
 
         //if emojis are shown & back button is pressed then hide emojis
         //or else simple close current screen on back button click
-        canPop: !_showEmoji,
-        onPopInvoked: (_) async {
-          if (_showEmoji) {
-            setState(() => _showEmoji = !_showEmoji);
-          } else {
-            Navigator.of(context).pop();
-          }
-        },
+        canPop: false,
+      onPopInvoked: (didPop) async {
+        if (didPop) {
+          return;
+        }
+        final navigator = Navigator.of(context);
+        if (_showEmoji) {
+          setState(() => _showEmoji = !_showEmoji);
+        } else {
+          navigator.pop();
+        }
+      },
 
         //
         child: Scaffold(


### PR DESCRIPTION
Hi Brother,

I watched your video tutorial on the Chat App and used your chat UI. However, I encountered an issue with the pop scope. In release mode, trying to go back from the chat screen to the home screen using the back button didn't work, and the back button in the app bar was also unresponsive. I managed to fix this problem in my app.